### PR TITLE
use the latest version of upload-artifact in GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ServerCoverageReport
-          path: Server/coveragereport\summary.html
+          path: Server/coveragereport/summary.html
 
   Client:
 


### PR DESCRIPTION
We are using `upload-artifact@v2.2.3` for no reason.  This PR updates it to use the latest version: `v3`.